### PR TITLE
Don’t hide the other option, when the textfield is shown.

### DIFF
--- a/select_or_other.js
+++ b/select_or_other.js
@@ -79,7 +79,6 @@
       $other_input.on('click', function () {
         $other_option.prop(prop, true).trigger('change');
       });
-      $other_option.not('option').closest('.form-item').hide();
     }
     $wrapper.bind('change', function(event, values) {
       // Replace change events in the select_or_other with change events on the wrapper.


### PR DESCRIPTION
This changes the behavior slightly when the other textfield is always shown: Previously the other option was hidden in this case and only selected implicity by clicking on the textfield, now it’s the responsibility of downstream to hide the option if needed.

Use-case: Some sites want to show the other option although the other textfield is shown always.